### PR TITLE
 fix: set Typo3Client as confidential per default

### DIFF
--- a/Classes/Domain/Entity/Typo3Client.php
+++ b/Classes/Domain/Entity/Typo3Client.php
@@ -18,7 +18,7 @@ class Typo3Client implements ClientEntityInterface, UserRelatedClientEntityInter
      */
     protected $userIdentifier;
 
-    public function __construct($identifier, string $name, array $redirectUri, string $userIdentifier = null, bool $isConfidential = false)
+    public function __construct($identifier, string $name, array $redirectUri, string $userIdentifier = null, bool $isConfidential = true)
     {
         $this->identifier = $identifier;
         $this->name = $name;

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,9 +1,5 @@
 <?php
 
-use DFAU\ToujouApi\Middleware\JsonApiPayload;
-use DFAU\ToujouApi\Middleware\ParsedBodyReset;
-use DFAU\ToujouApi\Middleware\Router;
-
 return [
     'frontend' => [
         'middlewares/payload/json-payload' => [


### PR DESCRIPTION
style: remove redundant class usages in middleware config
fix: set Typo3Client as confidential per default