### PR TITLE
fix: createUser in ResourceServerMiddleware as a missing session lead…

### DIFF
--- a/Classes/Middleware/ResourceServerMiddleware.php
+++ b/Classes/Middleware/ResourceServerMiddleware.php
@@ -67,6 +67,7 @@ class ResourceServerMiddleware implements MiddlewareInterface
             if (!empty($backendUserObject->user['uid'])) {
                 $backendUserObject->loginFailure = false;
                 $backendUserObject->fetchGroupData();
+                $backendUserObject->createUserSession($backendUserObject->user);
 
                 $GLOBALS['BE_USER'] = $backendUserObject;
 


### PR DESCRIPTION
…s to "Call to a member function getIdentifier() on null" error in AbstractUserAuthentication

e.g. \TYPO3\CMS\Core\Authentication\AbstractUserAuthentication::getModuleData used when updating page slugs & creating redirects


![image](https://github.com/DFAU/toujou-oauth2-server/assets/16890929/a7db469c-a087-48ff-a5b3-2cae5b6846ba)
